### PR TITLE
updated ram usage

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -89,7 +89,7 @@ class MC_Server_Controller:
         
         f_environment: list = [
             f'EULA=TRUE',
-            f'MEMORY={self.max_ram}',
+            f'JVM_OPTS=-Xms1G -Xmx{self.max_ram}',
             f'HARDCORE={self.hardcore}',
             f'DIFFICULTY={self.difficulty}',
         ]


### PR DESCRIPTION
Updated the docker container creation from using MEMORY to JVM_OPTS. When using MEMORY it sets the min and max ram to the given amount. This might cause an increase in lag. 